### PR TITLE
Update READMEs and explain how notifications could be split out

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p>Structure:</p>
 
-graphiql - A UI client for testing graphQL requests.
+graphiql - A UI client for testing graphQL requests.<br/>
 graphql - This makes the graphql endpoint available - it has a dependency to model.<br/>
 graphqlws - Configures websockes for graphql and sets up schema with event for subscribing to - needed for subscribing to notifications.</br>
 model - Basic JPA entity model for querying.<br/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # activiti-cloud-query-service 
+
+<p>Implements a query service that can be added to an application using starter. Supports either REST or GraphQL.</p>
+
+<p>Structure:</p>
+
+graphiql - A UI client for testing graphQL requests.
+graphql - This makes the graphql endpoint available - it has a dependency to model.<br/>
+graphqlws - Configures websockes for graphql and sets up schema with event for subscribing to - needed for subscribing to notifications.</br>
+model - Basic JPA entity model for querying.<br/>
+notifications - Transforms event stream for consumption by GraphQL - can be run as separate component (see module README).<br/>
+repo - Enables persistence for the core model.<br/>
+rest - Implementation for consuming event stream from runtime bundle and also provides REST endpoints (but not related to graphql). Uses spring data.<br/>
+stomp - Adds websocket dependency and /ws/stomp endpoint. Needed for subscribing to notifications.</br>
+
 [![Join the chat at https://gitter.im/Activiti/Activiti7](https://badges.gitter.im/Activiti/Activiti7.svg)](https://gitter.im/Activiti/Activiti7?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 <p>

--- a/activiti-cloud-services-query/README.md
+++ b/activiti-cloud-services-query/README.md
@@ -1,8 +1,8 @@
 # Query Service
 
-This service provides querying capabilities. It is distinct from the run-time API which is used to perform actions on engine items.
+This service provides querying capabilities. It is distinct from the run-time API which is used to perform actions on engine items. This implementation contains REST endpoints and GraphQL.
 
-## Approach
+## REST API Approach
 
 The service provides query endpoints with paging and sorting. So an example query might be e.g. /query/processinstances?status=RUNNING&page=0&size=10&sort=lastModified,desc
 
@@ -12,26 +12,6 @@ If the Q* classes aren't present in the /target/generated-sources directory then
 
 ## Database Support
 
-The implementation is using spring data in as agnostic a way as available so that alternative databases could be used. It is intended to verify that elasticsearch could be used if a ElasticsearchRepository were used in place of CrudRepository and an elastic instance were configured (https://www.mkyong.com/spring-boot/spring-boot-spring-data-elasticsearch-example/)
+The implementation is using spring data in as agnostic a way as available so that alternative databases could be used.
 
-The project has a split structure so that the activiti-cloud-services-query-repo module can be excluded and replaced with an alternative implementation
-
-## How to run
-
-Have the rabbitMQ and keycloak docker containers running - see the docker directory.
-
-Start the Application in the spring-boot-sample-hal-rest-api (e.g. from IDE). 
-
-To start a process submit the relevant post to the sample application. Its logs should show 'started on port(s)' to reveal which port. Use the postman collection called 'rest_calls_postman_collection.json' (elsewhere in Activiti).
-
-After starting a process you can query for tasks by going to e.g. http://localhost:55085/query/tasks/ where the port is that from the logs of the QueryApplication startup.
-
-## Outstanding
-
-//TODO: choose representative queries from the engine's java query API as rest queries. See TaskQueryTest, ProcessInstanceQueryTest etc.
-//TODO: implement chosen queries. See ProcessInstanceQueryController for implementing ORs and INs.
-//TODO: handle a wider range of events to support the above. See e.g. ActivitiStartedEventConverter for how events are emitted.
-//TODO: some problems with dates - how to handle times in searches? why do we get Could not write JSON: java.sql.Timestamp cannot be cast to java.lang.String error if certain dates are not annotated with JsonIgnore but only those dates? Maybe used zoned dates as in https://codexample.org/questions/620133/using-spring-restcontroller-with-querydslpredicate-to-handle-get-with-zoneddatetime-parameters.c ?
-// or LocalDateTime https://spring.io/blog/2011/04/26/advanced-spring-data-jpa-specifications-and-querydsl/ ?
-//TODO: use same testing approach as with https://github.com/Activiti/Activiti/tree/history-refactoring/activiti-cloud-services/activiti-cloud-services-query/src/test/java/org.activiti.cloud.services/query ? Or test differently now?
-//TODO: haven't given an example of an IN condition but it would be same as example we do have that shows adding OR condition except the parameter would need to be a list
+The project has a split structure so that the activiti-cloud-services-query-repo module can be excluded and replaced with an alternative implementation (e.g. (https://www.mkyong.com/spring-boot/spring-boot-spring-data-elasticsearch-example/) at least for the REST API. For GraphQL the schema is dynamically generated from the JPA entities so an alternative approach for defining the schema would then be needed.

--- a/activiti-cloud-services-query/activiti-cloud-services-query-notifications/README.md
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-notifications/README.md
@@ -1,0 +1,14 @@
+# Notifications Module 
+
+<p>This module consumes events made available by an Activiti runtime bundle (by default though the engineEvents destination). It transforms these events to a flattened format and passes on to queues for consumption by clients.</p>
+
+<p>For clients to subscribe to the queues they need to go through the GraphQL query module and register their subscription, either by calling the /ws/graphql endpoint or by calling /graphql and being automatically fed there. The event schema needs to be registered with GraphQL (which it is through the -ws module).</p>
+
+<p>The notifications gateway is a separable component that can be run in another container or pod.</p>
+
+<p>In order to separate:</p>
+
+- Remove the @EnableActivitiNotificationsGateway from the QueryApplication (otherwise gateway will be embedded in it)</br>
+- Create a new application called NotificationsApplication and add the @EnableActivitiNotificationsGateway annotation (it will need the activiti-cloud-services-query-notifications dependency)</br>
+- In its application.properties it will need the notificationsConsumer and notificationsGateway configuration that is currently in QueryApplication</br>
+- Create a docker image for the new notifications gateway application and add to deployment descriptors as desired.</br>


### PR DESCRIPTION
for https://github.com/Activiti/Activiti/issues/1712

I did separate notifications-gateway to run independently locally but committing that would add more repos with little immediate advantage. This PR would instead add a README so we could easily separate in the future if we need to.