### PR TITLE
Support loading GraphQL schema file from URL (classpath, file, or http)

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/java/org/activiti/cloud/services/query/qraphql/ws/schema/GraphQLSubscriptionSchemaBuilder.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/java/org/activiti/cloud/services/query/qraphql/ws/schema/GraphQLSubscriptionSchemaBuilder.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.services.query.qraphql.ws.schema;
 
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -29,6 +30,7 @@ import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
+import org.springframework.core.io.DefaultResourceLoader;
 
 public class GraphQLSubscriptionSchemaBuilder {
 
@@ -41,9 +43,15 @@ public class GraphQLSubscriptionSchemaBuilder {
         //
         // reads a file that provides the schema types
         //
-        Reader streamReader = loadSchemaFile(schemaFileName);
+        Reader streamReader;
+        try {
+            streamReader = loadSchemaFile(schemaFileName);
+        } catch (IOException cause) {
+            throw new RuntimeException(cause);
+        }
         this.typeRegistry = new SchemaParser().parse(streamReader);
         this.wiring = RuntimeWiring.newRuntimeWiring();
+
    }
 
     private GraphQLSchema buildSchema() {
@@ -72,8 +80,10 @@ public class GraphQLSubscriptionSchemaBuilder {
         		.orElseGet(this::buildSchema);
     }
 
-    private Reader loadSchemaFile(String name) {
-        InputStream stream = getClass().getClassLoader().getResourceAsStream(name);
+    protected Reader loadSchemaFile(String name) throws IOException {
+        DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
+
+        InputStream stream = resourceLoader.getResource(name).getInputStream();
         return new InputStreamReader(stream);
     }
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/java/org/activiti/cloud/services/query/qraphql/ws/schema/GraphQLSubscriptionSchemaProperties.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/java/org/activiti/cloud/services/query/qraphql/ws/schema/GraphQLSubscriptionSchemaProperties.java
@@ -29,7 +29,7 @@ import org.springframework.validation.annotation.Validated;
 public class GraphQLSubscriptionSchemaProperties {
 
     /**
-     * GraphQL subscription schema file name with .graphqls extension. Defaults to activiti.graphqls
+     * The URL of GraphQL subscription schema file name with .graphqls extension. Defaults to classpath:activiti.graphqls
      */
     @NotBlank
     private String graphqls;
@@ -48,7 +48,8 @@ public class GraphQLSubscriptionSchemaProperties {
     private String[] subscriptionArgumentNames;
 
     @Configuration
-    @PropertySource("classpath:org/activiti/cloud/services/query/graphql/ws/schema/default.properties")
+    @PropertySource("classpath:META-INF/graphql-ws-schema.properties")
+    @PropertySource(value = "classpath:graphql-ws-schema.properties", ignoreResourceNotFound = true)
     @EnableConfigurationProperties(GraphQLSubscriptionSchemaProperties.class)
     public static class AutoConfiguration {
         // auto configures parent properties class using spring.factories

--- a/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/resources/META-INF/graphql-ws-schema.properties
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/resources/META-INF/graphql-ws-schema.properties
@@ -1,0 +1,3 @@
+spring.activiti.cloud.services.query.graphql.ws.schema.graphqls=classpath:activiti.graphqls
+spring.activiti.cloud.services.query.graphql.ws.schema.subscription-field-name=ProcessEngineNotification
+spring.activiti.cloud.services.query.graphql.ws.schema.subscription-argument-names=serviceName,appName,processDefinitionId,processInstanceId

--- a/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/resources/org/activiti/cloud/services/query/graphql/ws/schema/default.properties
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/resources/org/activiti/cloud/services/query/graphql/ws/schema/default.properties
@@ -1,4 +1,0 @@
-spring.activiti.cloud.services.query.graphql.ws.schema.graphqls=activiti.graphqls
-spring.activiti.cloud.services.query.graphql.ws.schema.subscription-field-name=ProcessEngineNotification
-spring.activiti.cloud.services.query.graphql.ws.schema.subscription-argument-names=serviceName,appName,processDefinitionId,processInstanceId
-

--- a/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/test/java/org/activiti/cloud/services/query/graphql/ws/schema/GraphQLSubscriptionSchemaBuilderAutoConfigurationTest.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/test/java/org/activiti/cloud/services/query/graphql/ws/schema/GraphQLSubscriptionSchemaBuilderAutoConfigurationTest.java
@@ -50,7 +50,7 @@ public class GraphQLSubscriptionSchemaBuilderAutoConfigurationTest {
 
     @Test
     public void testGraphQLSubscriptionSchemaProperties() {
-        assertThat(properties.getGraphqls()).isEqualTo("activiti.graphqls");
+        assertThat(properties.getGraphqls()).isEqualTo("classpath:activiti.graphqls");
         assertThat(properties.getSubscriptionFieldName()).isEqualTo("ProcessEngineNotification");
         assertThat(properties.getSubscriptionArgumentNames()).isEqualTo(new String[]{"serviceName", "appName", "processDefinitionId", "processInstanceId"});
     }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/test/java/org/activiti/cloud/services/query/graphql/ws/schema/GraphQLSubscriptionSchemaBuilderTest.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/test/java/org/activiti/cloud/services/query/graphql/ws/schema/GraphQLSubscriptionSchemaBuilderTest.java
@@ -23,13 +23,28 @@ import org.junit.Test;
 public class GraphQLSubscriptionSchemaBuilderTest {
 
     @Test
-    public void testNotificationsSchemaBuilderParsesSchema() {
-        GraphQLSubscriptionSchemaBuilder schemaBuilder = new GraphQLSubscriptionSchemaBuilder("activiti.graphqls");
+    public void testNotificationsSchemaBuilderParsesSchemaFromClasspathURL() {
+        GraphQLSubscriptionSchemaBuilder schemaBuilder = new GraphQLSubscriptionSchemaBuilder("classpath:activiti.graphqls");
 
         assertThat(schemaBuilder.getGraphQLSchema()).isNotNull();
         assertThat(schemaBuilder.getGraphQLSchema().getSubscriptionType()).isNotNull();
         assertThat(schemaBuilder.getGraphQLSchema().getSubscriptionType().getName()).isEqualTo("Subscription");
         assertThat(schemaBuilder.getGraphQLSchema().getSubscriptionType().getFieldDefinition("ProcessEngineNotification")).isNotNull();
+    }
+
+    @Test
+    public void testNotificationsSchemaBuilderParsesSchemaFromHttpUrl() {
+        GraphQLSubscriptionSchemaBuilder schemaBuilder = new GraphQLSubscriptionSchemaBuilder("https://raw.githubusercontent.com/Activiti/activiti-cloud-query-service/develop/activiti-cloud-services-query/activiti-cloud-services-query-graphql-ws-schema/src/main/resources/activiti.graphqls");
+
+        assertThat(schemaBuilder.getGraphQLSchema()).isNotNull();
+        assertThat(schemaBuilder.getGraphQLSchema().getSubscriptionType()).isNotNull();
+        assertThat(schemaBuilder.getGraphQLSchema().getSubscriptionType().getName()).isEqualTo("Subscription");
+        assertThat(schemaBuilder.getGraphQLSchema().getSubscriptionType().getFieldDefinition("ProcessEngineNotification")).isNotNull();
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void testNotificationsSchemaBuilderParsesSchemaNotFoundRuntimeException() {
+        new GraphQLSubscriptionSchemaBuilder("http://notfound.com//activiti.graphqls");
     }
 
 }


### PR DESCRIPTION
This PR enables plug-able configuration of the GraphQL subscription schema definition via URL resource. See provided tests for details.

Closes #44