### PR TITLE
Optimize entity model query performance 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ hs_err_pid*
 .updatebot-repos/**
 
 *.versionsBackup
+
+.springBeans

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
@@ -56,13 +56,15 @@ public class ProcessInstanceEntity extends ActivitiEntityMetadata implements Clo
     private Date lastModifiedFrom;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "processInstance")
-    @org.hibernate.annotations.ForeignKey(name = "none")
+    @OneToMany(fetch=FetchType.LAZY)
+    @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false
+    	, foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private Set<TaskEntity> tasks;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "processInstance")
-    @org.hibernate.annotations.ForeignKey(name = "none")
+    @OneToMany(fetch=FetchType.LAZY)
+    @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false
+		, foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private Set<VariableEntity> variables;
 
     public ProcessInstanceEntity() {

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
@@ -18,10 +18,15 @@ package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
 import java.util.Set;
+
+import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -30,8 +35,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity(name="ProcessInstance")
-@Table(name = "PROCESS_INSTANCE")
+@Table(name = "PROCESS_INSTANCE",
+		indexes= {
+				@Index(name="pi_status_idx", columnList="status", unique=false),
+				@Index(name="pi_businessKey_idx", columnList="businessKey", unique=false),
+				@Index(name="pi_name_idx", columnList="name", unique=false),
+				@Index(name="pi_processDefinitionId_idx", columnList="processDefinitionId", unique=false),
+				@Index(name="pi_processDefinitionKey_idx", columnList="processDefinitionKey", unique=false)
+		})
 public class ProcessInstanceEntity extends ActivitiEntityMetadata implements CloudProcessInstance {
 
     @Id

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroup.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroup.java
@@ -17,7 +17,7 @@ public class TaskCandidateGroup {
     @Id
     private String groupId;
 
-    @ManyToOne(optional = true)
+    @ManyToOne(optional = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false, nullable = true
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private TaskEntity task;

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroup.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroup.java
@@ -2,12 +2,20 @@ package org.activiti.cloud.services.query.model;
 
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity(name="TaskCandidateGroup")
+@Table(name="TASK_CANDIDATE_GROUP", indexes= {
+		@Index(name="tcg_groupId_idx", columnList="groupId", unique=false),
+		@Index(name="tcg_taskId_idx", columnList="taskId", unique=false)
+	}
+)
 @IdClass(TaskCandidateGroupId.class)
 public class TaskCandidateGroup {
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUser.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUser.java
@@ -2,10 +2,13 @@ package org.activiti.cloud.services.query.model;
 
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -15,6 +18,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Entity(name="TaskCandidateUser")
 @IdClass(TaskCandidateUserId.class)
+@Table(name="TASK_CANDIDATE_USER", indexes= {
+		@Index(name="tcu_userId_idx", columnList="userId", unique=false),
+		@Index(name="tcu_taskId_idx", columnList="taskId", unique=false)
+	}
+)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskCandidateUser {

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUser.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUser.java
@@ -26,7 +26,7 @@ public class TaskCandidateUser {
     private String userId;
 
     @JsonIgnore
-    @ManyToOne(optional = true)
+    @ManyToOne(optional = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false, nullable = true
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private TaskEntity task;

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
@@ -18,12 +18,14 @@ package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
 import java.util.Set;
+
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
@@ -35,8 +37,14 @@ import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity(name="Task")
-@Table(name = "TASK")
+@Table(name = "TASK",
+	indexes= {
+		@Index(name="task_status_idx", columnList="status", unique=false),
+		@Index(name="task_processInstance_idx", columnList="processInstanceId", unique=false)
+})
 public class TaskEntity extends ActivitiEntityMetadata implements CloudTask {
 
     /**

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
@@ -74,25 +74,25 @@ public class TaskEntity extends ActivitiEntityMetadata implements CloudTask {
     private Date lastModifiedFrom;
 
     @JsonIgnore
-    @ManyToOne(optional = true)
+    @ManyToOne(optional = true, fetch=FetchType.LAZY)
     @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private ProcessInstanceEntity processInstance;
 
     @JsonIgnore
-    @OneToMany(fetch = FetchType.EAGER)
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private Set<TaskCandidateUser> taskCandidateUsers;
 
     @JsonIgnore
-    @OneToMany(fetch = FetchType.EAGER)
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private Set<TaskCandidateGroup> taskCandidateGroups;
 
     @JsonIgnore
-    @OneToMany(fetch = FetchType.EAGER)
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private Set<VariableEntity> variables;

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableEntity.java
@@ -58,20 +58,20 @@ public class VariableEntity extends ActivitiEntityMetadata implements CloudVaria
     private String executionId;
 
     @Convert(converter = VariableValueJsonConverter.class)
-    @Lob
+    @Lob @Basic(fetch=FetchType.LAZY)
     @Column
     private VariableValue<?> value;
 
     private Boolean markedAsDeleted = false;
 
     @JsonIgnore
-    @ManyToOne(optional = true)
+    @ManyToOne(optional = true, fetch=FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false, nullable = true
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private TaskEntity task;
 
     @JsonIgnore
-    @ManyToOne(optional = true)
+    @ManyToOne(optional = true, fetch=FetchType.LAZY)
     @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false
             , foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private ProcessInstanceEntity processInstance;

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableEntity.java
@@ -17,13 +17,17 @@
 package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
+
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
@@ -33,8 +37,16 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity(name="Variable")
-@Table(name = "VARIABLE")
+@Table(	name = "VARIABLE",
+		indexes = { 
+				@Index(name = "variable_processInstanceId_idx", columnList = "processInstanceId", unique = false), 
+				@Index(name = "variable_taskId_idx", columnList = "taskId", unique = false),
+				@Index(name = "variable_name_idx", columnList = "name", unique = false), 
+				@Index(name = "variable_executionId_idx", columnList = "executionId", unique = false) 
+		})
 public class VariableEntity extends ActivitiEntityMetadata implements CloudVariableInstance {
 
     @Id

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValue.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValue.java
@@ -18,7 +18,7 @@ package org.activiti.cloud.services.query.model;
 
 public class VariableValue<T> {
 
-    private T value;
+	private T value;
 
     public VariableValue() {
     }
@@ -27,7 +27,47 @@ public class VariableValue<T> {
         this.value = value;
     }
 
-    public T getValue() {
+	public T getValue() {
         return value;
     }
+    
+    
+    /**
+     * Encountered Java type [class org.activiti.cloud.services.query.model.VariableValue] for which we could not locate a JavaTypeDescriptor 
+     * and which does not appear to implement equals and/or hashCode.  This can lead to significant performance problems when performing 
+     * equality/dirty checking involving this Java type.  
+     * 
+     * Consider registering a custom JavaTypeDescriptor or at least implementing equals/hashCode. 
+     * 
+     */
+    @Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((value == null) ? 0 : value.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		VariableValue<?> other = (VariableValue<?>) obj;
+		if (value == null) {
+			if (other.value != null)
+				return false;
+		} else if (!value.equals(other.value))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "VariableValue [value=" + value + "]";
+	}
+	
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
@@ -16,7 +16,6 @@
 
 package org.activiti.cloud.services.query.model;
 
-import java.io.IOException;
 import javax.persistence.AttributeConverter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -44,10 +43,25 @@ public class VariableValueJsonConverter implements AttributeConverter<VariableVa
 
     @Override
     public VariableValue<?> convertToEntityAttribute(String dbData) {
-        try {
-            return objectMapper.readValue(dbData, VariableValue.class);
-        } catch (IOException e) {
-            throw new QueryException("Unable to deserialize variable.", e);
+    	return new LazyVariableValue<Object>(dbData);
+    }
+
+    class LazyVariableValue<T> extends VariableValue<T> {
+        private String rawValue;
+    	
+        LazyVariableValue(String json) {
+        	this.rawValue = json;
+        }
+        
+        @SuppressWarnings("unchecked")
+		@Override
+        public T getValue() {
+        	try {
+				return (T) objectMapper.readValue(rawValue, VariableValue.class)
+								.getValue();
+			} catch (Throwable cause) {
+				return null;
+			}
         }
     }
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
@@ -61,7 +61,7 @@ public class VariableValueJsonConverter implements AttributeConverter<VariableVa
 	        	try {
 	       			value = objectMapper.readValue(rawValue, VariableValue.class);
 				} catch (Throwable cause) {
-					return null;
+					throw new QueryException("Unable to deserialize variable.", cause);
 				}
         	}
         	

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
@@ -16,6 +16,7 @@
 
 package org.activiti.cloud.services.query.model;
 
+import java.io.IOException;
 import javax.persistence.AttributeConverter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -43,29 +44,10 @@ public class VariableValueJsonConverter implements AttributeConverter<VariableVa
 
     @Override
     public VariableValue<?> convertToEntityAttribute(String dbData) {
-    	return new LazyVariableValue<Object>(dbData);
-    }
-
-    class LazyVariableValue<T> extends VariableValue<T> {
-        private String rawValue;
-        private VariableValue<T> value;
-    	
-        LazyVariableValue(String json) {
-        	this.rawValue = json;
-        }
-        
-        @SuppressWarnings("unchecked")
-		@Override
-        public T getValue() {
-        	if(value == null) {
-	        	try {
-	       			value = objectMapper.readValue(rawValue, VariableValue.class);
-				} catch (Throwable cause) {
-					throw new QueryException("Unable to deserialize variable.", cause);
-				}
-        	}
-        	
-        	return value.getValue();
+        try {
+            return objectMapper.readValue(dbData, VariableValue.class);
+        } catch (IOException e) {
+            throw new QueryException("Unable to deserialize variable.", e);
         }
     }
     

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableValueJsonConverter.java
@@ -48,6 +48,7 @@ public class VariableValueJsonConverter implements AttributeConverter<VariableVa
 
     class LazyVariableValue<T> extends VariableValue<T> {
         private String rawValue;
+        private VariableValue<T> value;
     	
         LazyVariableValue(String json) {
         	this.rawValue = json;
@@ -56,12 +57,16 @@ public class VariableValueJsonConverter implements AttributeConverter<VariableVa
         @SuppressWarnings("unchecked")
 		@Override
         public T getValue() {
-        	try {
-				return (T) objectMapper.readValue(rawValue, VariableValue.class)
-								.getValue();
-			} catch (Throwable cause) {
-				return null;
-			}
+        	if(value == null) {
+	        	try {
+	       			value = objectMapper.readValue(rawValue, VariableValue.class);
+				} catch (Throwable cause) {
+					return null;
+				}
+        	}
+        	
+        	return value.getValue();
         }
     }
+    
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/test/java/org/activiti/cloud/services/query/model/VariableValueJsonConverterTest.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/test/java/org/activiti/cloud/services/query/model/VariableValueJsonConverterTest.java
@@ -16,19 +16,18 @@
 
 package org.activiti.cloud.services.query.model;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.MockitoAnnotations.initMocks;
-
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class VariableValueJsonConverterTest {
 
@@ -85,7 +84,7 @@ public class VariableValueJsonConverterTest {
         VariableValue<?> convertedValue = converter.convertToEntityAttribute(JSON_REPRESENTATION);
 
         //then
-        assertThat(convertedValue.getValue()).isEqualTo(ENTITY_REPRESENTATION.getValue());
+        assertThat(convertedValue).isEqualTo(ENTITY_REPRESENTATION);
     }
 
     @Test
@@ -96,7 +95,7 @@ public class VariableValueJsonConverterTest {
                                      VariableValue.class)).willThrow(ioException);
 
         //when
-        Throwable thrown = catchThrowable(() -> converter.convertToEntityAttribute(JSON_REPRESENTATION).getValue());
+        Throwable thrown = catchThrowable(() -> converter.convertToEntityAttribute(JSON_REPRESENTATION));
 
         //then
         assertThat(thrown)

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/test/java/org/activiti/cloud/services/query/model/VariableValueJsonConverterTest.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/test/java/org/activiti/cloud/services/query/model/VariableValueJsonConverterTest.java
@@ -16,18 +16,19 @@
 
 package org.activiti.cloud.services.query.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import java.io.IOException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.MockitoAnnotations.initMocks;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class VariableValueJsonConverterTest {
 
@@ -84,7 +85,7 @@ public class VariableValueJsonConverterTest {
         VariableValue<?> convertedValue = converter.convertToEntityAttribute(JSON_REPRESENTATION);
 
         //then
-        assertThat(convertedValue).isEqualTo(ENTITY_REPRESENTATION);
+        assertThat(convertedValue.getValue()).isEqualTo(ENTITY_REPRESENTATION.getValue());
     }
 
     @Test
@@ -95,7 +96,7 @@ public class VariableValueJsonConverterTest {
                                      VariableValue.class)).willThrow(ioException);
 
         //when
-        Throwable thrown = catchThrowable(() -> converter.convertToEntityAttribute(JSON_REPRESENTATION));
+        Throwable thrown = catchThrowable(() -> converter.convertToEntityAttribute(JSON_REPRESENTATION).getValue());
 
         //then
         assertThat(thrown)


### PR DESCRIPTION
Lazy loading of associations between entities is a well established best practice in JPA. Its main goal is to retrieve only the requested entities from the database and load the related entities only if needed.

The use of FetchType.EAGER  for associations mapping is one of the most common reasons for performance problems, because Hibernate loads eagerly fetched associations when it loads an entity. E.g., when Hibernate loads a Task entity, it also fetches the associated ProcessInstance, Variables, TaskCandidateUsers and TaskCandidateGroups entities. That requires an additional query for each associations and creates dozens or even hundreds of additional queries. This approach is very inefficient and it gets even worse when you consider that Hibernate does that whether or not you will use the association. 

This PR makes explicit use of FetchType.LAZY for all to-many associations. It delays the initialization of the relationship until we use it in business code and avoids a lot of unnecessary queries and improves the performance of query application. It also prevents default eager fetching  of all to-one associations, when loading multiple entities and each of them specify a few of these associations.

It is also enables sensible database indexes  to improve search performance.

Another improvement is to use lazy variable value de-serialization on first property access 
