### PR TITLE
Start Process With Process Instance Name via rest and Java APIs #1952

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessCreatedEventHandler.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessCreatedEventHandler.java
@@ -56,6 +56,7 @@ public class ProcessCreatedEventHandler implements QueryEventHandler {
         createdProcessInstanceEntity.setId(createdEvent.getEntity().getId());
         createdProcessInstanceEntity.setStatus(ProcessInstance.ProcessInstanceStatus.CREATED);
         createdProcessInstanceEntity.setLastModified(new Date(createdEvent.getTimestamp()));
+        createdProcessInstanceEntity.setName(createdEvent.getEntity().getName());
 
         createdProcessInstanceEntity.setProcessDefinitionKey(createdEvent.getEntity().getProcessDefinitionKey());
         createdProcessInstanceEntity.setInitiator(createdEvent.getEntity().getInitiator());

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/ProcessCreatedEventHandlerTest.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/ProcessCreatedEventHandlerTest.java
@@ -71,7 +71,8 @@ public class ProcessCreatedEventHandlerTest {
                 .hasProcessDefinitionId(event.getEntity().getProcessDefinitionId())
                 .hasServiceName(event.getServiceName())
                 .hasProcessDefinitionKey(event.getEntity().getProcessDefinitionKey())
-                .hasStatus(ProcessInstance.ProcessInstanceStatus.CREATED);
+                .hasStatus(ProcessInstance.ProcessInstanceStatus.CREATED)
+                .hasName(event.getEntity().getName());
     }
 
     private CloudProcessCreatedEvent buildProcessCreatedEvent() {
@@ -79,6 +80,7 @@ public class ProcessCreatedEventHandlerTest {
         processInstance.setId(UUID.randomUUID().toString());
         processInstance.setProcessDefinitionId(UUID.randomUUID().toString());
         processInstance.setBusinessKey("myKey");
+        processInstance.setName("myName");
         CloudProcessCreatedEventImpl event = new CloudProcessCreatedEventImpl(processInstance);
         event.setServiceName("runtime-bundle-a");
         return event;


### PR DESCRIPTION
- fix _name_ not being saved to query service

[#1952](https://github.com/Activiti/Activiti/issues/1952)