### PR TITLE
Fix test validating the Alfresco response format for a Task

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityControllerIT.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityControllerIT.java
@@ -143,7 +143,6 @@ public class TaskEntityControllerIT {
     }
 
     @Test
-    @Ignore //@TODO: we need to update the docs that are being checked for alfresco types
     public void findByIdShouldUseAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {
         //given
         TaskEntity taskEntity = buildDefaultTask();


### PR DESCRIPTION
- fixed test validating the Alfresco response metadata for a task part of #2066 work

note: probably will need a rebase before merge since will need a new version of _cloud-common-service_  >=7.0.36