### PR TITLE
fix: (model) replace @Lob annotation on VariableValue attribute with TEXT column definition

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/VariableEntity.java
@@ -18,7 +18,6 @@ package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
 
-import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
 import javax.persistence.Convert;
@@ -29,7 +28,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -69,8 +67,7 @@ public class VariableEntity extends ActivitiEntityMetadata implements CloudVaria
     private String executionId;
 
     @Convert(converter = VariableValueJsonConverter.class)
-    @Lob @Basic(fetch=FetchType.LAZY)
-    @Column
+    @Column(columnDefinition="text")
     private VariableValue<?> value;
 
     private Boolean markedAsDeleted = false;


### PR DESCRIPTION
This PR proposes to fix #105 by removing `@Lob` annotation on VariableValue attribute and augmenting its `@Column` annotation with TEXT column definition in order to store JSON strings of any length for serialized variable values. 

This change will break the compatibility for any existing database schema used to be generated previously with `@Lob` annotation.

Although the type text is not in the SQL standard, several other SQL database management systems have it as well: https://www.postgresql.org/docs/current/static/datatype-character.html
 
See for details some performance tests: https://www.depesz.com/2010/03/02/charx-vs-varcharx-vs-varchar-vs-text/