### PR TITLE
Fix process definitions collection rel name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,11 +104,5 @@ pipeline {
         always {
             cleanWs()
         }
-        failure {
-            input """Pipeline failed. 
-We will keep the build pod around to help you diagnose any failures. 
-
-Select Proceed or Abort to terminate the build pod"""
-        }
     }
   }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/QueryRelProvider.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/QueryRelProvider.java
@@ -21,8 +21,11 @@ import java.util.Map;
 
 import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.hateoas.RelProvider;
 
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class QueryRelProvider implements RelProvider {
 
     private Map<Class<?>, ResourceRelationDescriptor> resourceRelationDescriptors;


### PR DESCRIPTION
When using hal format the collection relation name should be `processDefinitions` instead of `processDefinitionEntities`. The custome relation provider was there, but it was loaded with low priority and it was not taken in account.

It used to be
```
{
    "_embedded": {
        "processDefinitionEntities": [
            { ...}
            ]
     }
}
```

Instead it should be
```
{
    "_embedded": {
        "processDefinitions": [
            { ...}
            ]
     }
}
```

Refs https://github.com/Activiti/Activiti/issues/1745 for process definitions in query-service.