### PR TITLE
Temporary solution to get root tasks

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -20,9 +20,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.model.QTaskEntity;
 import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.query.resources.TaskResource;
 import org.activiti.cloud.services.query.rest.assembler.TaskResourceAssembler;
@@ -87,6 +89,16 @@ public class TaskAdminController {
     public PagedResources<TaskResource> allTasks(@QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
                                                  Pageable pageable) {
 
+        //when request is made for the root tasks only replace (= null) with (is null)
+        String s = predicate !=null ? predicate.toString() : null;
+        if (s != null) {
+            if (s.contains("parentTaskId = null")) {
+                QTaskEntity task = QTaskEntity.taskEntity;
+                BooleanExpression parentTaskNull = task.parentTaskId.isNull();
+                predicate = parentTaskNull;
+            }
+        }
+        
         Page<TaskEntity> page = taskRepository.findAll(predicate,
                                                        pageable);
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
@@ -100,7 +101,16 @@ public class TaskController {
     @RequestMapping(method = RequestMethod.GET)
     public PagedResources<TaskResource> findAll(@QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
                                                 Pageable pageable) {
-
+        //when request is made for the root tasks only replace (= null) with (is null)
+        String s = predicate !=null ? predicate.toString() : null;
+        if (s != null) {
+            if (s.contains("parentTaskId = null")) {
+                QTaskEntity task = QTaskEntity.taskEntity;
+                BooleanExpression parentTaskNull = task.parentTaskId.isNull();
+                predicate = parentTaskNull;
+            }
+        }
+        
         Predicate extendedPredicate = taskLookupRestrictionService.restrictTaskQuery(predicate);
         Page<TaskEntity> page = taskRepository.findAll(extendedPredicate,
                                                        pageable);

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -101,16 +101,7 @@ public class TaskController {
     @RequestMapping(method = RequestMethod.GET)
     public PagedResources<TaskResource> findAll(@QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
                                                 Pageable pageable) {
-        //when request is made for the root tasks only replace (= null) with (is null)
-        String s = predicate !=null ? predicate.toString() : null;
-        if (s != null) {
-            if (s.contains("parentTaskId = null")) {
-                QTaskEntity task = QTaskEntity.taskEntity;
-                BooleanExpression parentTaskNull = task.parentTaskId.isNull();
-                predicate = parentTaskNull;
-            }
-        }
-        
+   
         Predicate extendedPredicate = taskLookupRestrictionService.restrictTaskQuery(predicate);
         Page<TaskEntity> page = taskRepository.findAll(extendedPredicate,
                                                        pageable);
@@ -119,7 +110,24 @@ public class TaskController {
                                                   page,
                                                   taskResourceAssembler);
     }
+    
+    @RequestMapping(value = "/rootTasksOnly",method = RequestMethod.GET)
+    public PagedResources<TaskResource> getRootTasks(@QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
+                                                     Pageable pageable) {
+        //when request is made for the root tasks set a special condition parentTaskId is null
+        BooleanExpression parentTaskNull = QTaskEntity.taskEntity.parentTaskId.isNull(); 
+        predicate= predicate !=null ? parentTaskNull.and(predicate) : parentTaskNull;
+              
+        Predicate extendedPredicate = taskLookupRestrictionService.restrictTaskQuery(predicate);
+        Page<TaskEntity> page = taskRepository.findAll(extendedPredicate,
+                                                       pageable);
 
+        return pagedResourcesAssembler.toResource(pageable,
+                                                  page,
+                                                  taskResourceAssembler);
+    }
+    
+    
     @RequestMapping(value = "/{taskId}", method = RequestMethod.GET)
     public TaskResource findById(@PathVariable String taskId) {
 

--- a/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -266,7 +266,7 @@ public class QueryTasksIT {
     }
     
     @Test
-    public void shouldGetAvailableTasksAndFilterOnParentIdNull() {
+    public void shouldGetAvailableRootTasks() {
         //given
         TaskImpl rootTask = new TaskImpl(UUID.randomUUID().toString(),
                                      "Root task",
@@ -286,7 +286,7 @@ public class QueryTasksIT {
 
         await().untilAsserted(() -> {
             //when
-            ResponseEntity<PagedResources<Task>> responseEntity = testRestTemplate.exchange(TASKS_URL + "?parentTaskId=null",
+            ResponseEntity<PagedResources<Task>> responseEntity = testRestTemplate.exchange(TASKS_URL + "/rootTasksOnly",
                                                                                             HttpMethod.GET,
                                                                                             keycloakTokenProducer.entityWithAuthorizationHeader(),
                                                                                             PAGED_TASKS_RESPONSE_TYPE);

--- a/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -22,6 +22,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.task.model.Task;
@@ -33,6 +34,7 @@ import org.activiti.cloud.api.task.model.impl.events.CloudTaskCandidateGroupAdde
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskCandidateGroupRemovedEventImpl;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskCandidateUserAddedEventImpl;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskCandidateUserRemovedEventImpl;
+import org.activiti.cloud.api.task.model.impl.events.CloudTaskCreatedEventImpl;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskUpdatedEventImpl;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.cloud.services.query.app.repository.TaskCandidateGroupRepository;
@@ -261,6 +263,43 @@ public class QueryTasksIT {
         eventsAggregator.sendAll();
 
         checkExistingTask(createdTask);
+    }
+    
+    @Test
+    public void shouldGetAvailableTasksAndFilterOnParentIdNull() {
+        //given
+        TaskImpl rootTask = new TaskImpl(UUID.randomUUID().toString(),
+                                     "Root task",
+                                     Task.TaskStatus.CREATED);
+        rootTask.setProcessInstanceId(runningProcessInstance.getId());
+        rootTask.setParentTaskId(null);
+        eventsAggregator.addEvents(new CloudTaskCreatedEventImpl(rootTask));
+        
+        TaskImpl task = new TaskImpl(UUID.randomUUID().toString(),
+                                     "Task with parent",
+                                     Task.TaskStatus.CREATED);
+        task.setProcessInstanceId(runningProcessInstance.getId());
+        task.setParentTaskId(rootTask.getId());
+        eventsAggregator.addEvents(new CloudTaskCreatedEventImpl(task));
+        
+        eventsAggregator.sendAll();
+
+        await().untilAsserted(() -> {
+            //when
+            ResponseEntity<PagedResources<Task>> responseEntity = testRestTemplate.exchange(TASKS_URL + "?parentTaskId=null",
+                                                                                            HttpMethod.GET,
+                                                                                            keycloakTokenProducer.entityWithAuthorizationHeader(),
+                                                                                            PAGED_TASKS_RESPONSE_TYPE);
+            //then
+            assertThat(responseEntity).isNotNull();
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            assertThat(responseEntity.getBody()).isNotNull();
+            Collection<Task> tasks = responseEntity.getBody().getContent();
+            assertThat(tasks)
+                    .extracting(Task::getId)
+                    .containsExactly(rootTask.getId());
+        });
     }
 
     private void checkExistingTask(Task createdTask) {


### PR DESCRIPTION
Related to https://github.com/Activiti/Activiti/issues/1893
This is a temporary solution to get root tasks. 
To handle this proper we have to consider following.
We have a possibility to filter query by condition: something=somevalue.
We do not have a possibility to filter query by conditions: something != somevalue, something < somevalue, something < somevalue, something is null, something is not null, etc.
To implement this we may implement (additionally) a new method with a “search“ parameter to pass in the query string, like here (UserController): 
https://www.baeldung.com/rest-api-search-language-spring-data-querydsl
