### PR TITLE
TaskUpdatedEventHandler corrected to store formKey and parentTaskId, assignee removed

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskUpdatedEventHandler.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskUpdatedEventHandler.java
@@ -48,13 +48,14 @@ public class TaskUpdatedEventHandler implements QueryEventHandler {
                 () -> new QueryException("Unable to find task with id: " + eventTask.getId())
         );
 
+        queryTaskEntity.setLastModified(new Date(taskUpdatedEvent.getTimestamp()));
         queryTaskEntity.setName(eventTask.getName());
         queryTaskEntity.setDescription(eventTask.getDescription());
         queryTaskEntity.setPriority(eventTask.getPriority());
-        queryTaskEntity.setAssignee(eventTask.getAssignee());
         queryTaskEntity.setDueDate(eventTask.getDueDate());
-        queryTaskEntity.setLastModified(new Date(taskUpdatedEvent.getTimestamp()));
-
+        queryTaskEntity.setFormKey(eventTask.getFormKey());
+        queryTaskEntity.setParentTaskId(eventTask.getParentTaskId());
+        
         taskRepository.save(queryTaskEntity);
     }
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskUpdatedEventHandler.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskUpdatedEventHandler.java
@@ -48,13 +48,14 @@ public class TaskUpdatedEventHandler implements QueryEventHandler {
                 () -> new QueryException("Unable to find task with id: " + eventTask.getId())
         );
 
-        queryTaskEntity.setLastModified(new Date(taskUpdatedEvent.getTimestamp()));
+       
         queryTaskEntity.setName(eventTask.getName());
         queryTaskEntity.setDescription(eventTask.getDescription());
         queryTaskEntity.setPriority(eventTask.getPriority());
         queryTaskEntity.setDueDate(eventTask.getDueDate());
         queryTaskEntity.setFormKey(eventTask.getFormKey());
         queryTaskEntity.setParentTaskId(eventTask.getParentTaskId());
+        queryTaskEntity.setLastModified(new Date(taskUpdatedEvent.getTimestamp()));
         
         taskRepository.save(queryTaskEntity);
     }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskBuilder.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskBuilder.java
@@ -16,10 +16,12 @@
 
 package org.activiti.cloud.services.query.events.handlers;
 
-import org.activiti.cloud.services.query.model.TaskEntity;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.activiti.cloud.services.query.model.TaskEntity;
 
 public class TaskBuilder {
 
@@ -37,12 +39,42 @@ public class TaskBuilder {
         when(taskEntity.getId()).thenReturn(taskId);
         return this;
     }
+    
+    public TaskBuilder withName(String name) {
+        when(taskEntity.getName()).thenReturn(name);
+        return this;
+    }
 
+    public TaskBuilder withDescription(String description) {
+        when(taskEntity.getDescription()).thenReturn(description);
+        return this;
+    }
+    
+    public TaskBuilder withPriority(Integer priority) {
+        when(taskEntity.getPriority()).thenReturn(priority);
+        return this;
+    }
+    
+    public TaskBuilder withDueDate(Date dueDate) {
+        when(taskEntity.getDueDate()).thenReturn(dueDate);
+        return this;
+    }
+    
+    public TaskBuilder withFormKey(String formKey) {
+        when(taskEntity.getFormKey()).thenReturn(formKey);
+        return this;
+    }
+    
+    public TaskBuilder withParentTaskId(String parentTaskId) {
+        when(taskEntity.getParentTaskId()).thenReturn(parentTaskId);
+        return this;
+    }
+    
     public TaskBuilder withAssignee(String assignee) {
         when(taskEntity.getAssignee()).thenReturn(assignee);
         return this;
     }
-
+    
     public TaskEntity build() {
         return taskEntity;
     }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskEntityUpdatedEventHandlerTest.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskEntityUpdatedEventHandlerTest.java
@@ -16,6 +16,14 @@
 
 package org.activiti.cloud.services.query.events.handlers;
 
+import static org.activiti.cloud.services.query.events.handlers.TaskBuilder.aTask;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,13 +42,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
-import static org.activiti.cloud.services.query.events.handlers.TaskBuilder.aTask;
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class TaskEntityUpdatedEventHandlerTest {
 
@@ -64,7 +65,10 @@ public class TaskEntityUpdatedEventHandlerTest {
         CloudTaskUpdatedEvent event = buildTaskUpdateEvent();
         String taskId = event.getEntity().getId();
         TaskEntity eventTaskEntity = aTask().withId(taskId)
-                .withAssignee("user")
+                .withName("name")
+                .withDescription("description")
+                .withPriority(10)
+                .withFormKey("formKey")
                 .build();
 
         given(taskRepository.findById(taskId)).willReturn(Optional.of(eventTaskEntity));
@@ -77,9 +81,11 @@ public class TaskEntityUpdatedEventHandlerTest {
         verify(eventTaskEntity).setName(event.getEntity().getName());
         verify(eventTaskEntity).setDescription(event.getEntity().getDescription());
         verify(eventTaskEntity).setPriority(event.getEntity().getPriority());
-        verify(eventTaskEntity).setAssignee(event.getEntity().getAssignee());
         verify(eventTaskEntity).setDueDate(event.getEntity().getDueDate());
+        verify(eventTaskEntity).setFormKey(event.getEntity().getFormKey());
+        verify(eventTaskEntity).setParentTaskId(event.getEntity().getParentTaskId());
         verify(eventTaskEntity).setLastModified(any(Date.class));
+        
         verifyNoMoreInteractions(eventTaskEntity);
     }
 

--- a/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -188,10 +188,11 @@ public class QueryTasksIT {
         TaskImpl updatedTask = new TaskImpl(assignedTask.getId(),
                                             assignedTask.getName(),
                                             assignedTask.getStatus());
-        updatedTask.setAssignee(assignedTask.getAssignee());
         updatedTask.setProcessInstanceId(assignedTask.getProcessInstanceId());
+        updatedTask.setName("Updated name");
         updatedTask.setDescription("Updated description");
         updatedTask.setPriority(42);
+        updatedTask.setFormKey("FormKey");
 
         //when
         producer.send(new CloudTaskUpdatedEventImpl(updatedTask));
@@ -209,8 +210,10 @@ public class QueryTasksIT {
 
             assertThat(responseEntity.getBody()).isNotNull();
             Task task = responseEntity.getBody();
-            assertThat(task.getDescription()).isEqualTo("Updated description");
-            assertThat(task.getPriority()).isEqualTo(42);
+            assertThat(task.getName()).isEqualTo(updatedTask.getName());
+            assertThat(task.getDescription()).isEqualTo(updatedTask.getDescription());
+            assertThat(task.getPriority()).isEqualTo(updatedTask.getPriority());
+            assertThat(task.getFormKey()).isEqualTo(updatedTask.getFormKey());
         });
     }
 


### PR DESCRIPTION
Related to https://github.com/Activiti/Activiti/issues/2322
setAssignee removed for queryTaskEntity, because it is not possible to update assignee using update command