### PR TITLE
Synced status of a released task in RB and Query

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskUpdatedEventHandler.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskUpdatedEventHandler.java
@@ -44,7 +44,6 @@ public class TaskUpdatedEventHandler implements QueryEventHandler {
                 () -> new QueryException("Unable to find task with id: " + eventTask.getId())
         );
 
-       
         queryTaskEntity.setName(eventTask.getName());
         queryTaskEntity.setDescription(eventTask.getDescription());
         queryTaskEntity.setPriority(eventTask.getPriority());
@@ -52,6 +51,7 @@ public class TaskUpdatedEventHandler implements QueryEventHandler {
         queryTaskEntity.setFormKey(eventTask.getFormKey());
         queryTaskEntity.setParentTaskId(eventTask.getParentTaskId());
         queryTaskEntity.setLastModified(new Date(taskUpdatedEvent.getTimestamp()));
+        queryTaskEntity.setStatus(eventTask.getStatus());
         
         taskRepository.save(queryTaskEntity);
     }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskEntityUpdatedEventHandlerTest.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskEntityUpdatedEventHandlerTest.java
@@ -85,7 +85,8 @@ public class TaskEntityUpdatedEventHandlerTest {
         verify(eventTaskEntity).setFormKey(event.getEntity().getFormKey());
         verify(eventTaskEntity).setParentTaskId(event.getEntity().getParentTaskId());
         verify(eventTaskEntity).setLastModified(any(Date.class));
-        
+        verify(eventTaskEntity).setStatus(event.getEntity().getStatus());
+
         verifyNoMoreInteractions(eventTaskEntity);
     }
 

--- a/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -854,6 +854,31 @@ public class QueryTasksIT {
         });
 
     }
+
+    @Test
+    public void shouldHaveCreatedStatusAfterBeingReleased(){
+        Task releasedTask = taskEventContainedBuilder.aReleasedTask("released-task");
+
+        eventsAggregator.sendAll();
+
+        await().untilAsserted(() -> {
+
+            //when
+            ResponseEntity<Task> responseEntity = executeRequestGetTasksById(releasedTask.getId());
+
+            //then
+            assertThat(responseEntity).isNotNull();
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            assertThat(responseEntity.getBody()).isNotNull();
+            Task task = responseEntity.getBody();
+
+            assertThat(task.getName()).isEqualTo("released-task");
+            assertThat(task.getStatus()).isEqualTo(Task.TaskStatus.CREATED);
+
+        });
+
+    }
     
     @Test
     public void shouldGetAvailableStandaloneTasksFilteredByNameDescription() {


### PR DESCRIPTION
Addressing this issue:
https://github.com/Activiti/Activiti/issues/2638

Dependent on:
https://github.com/Activiti/activiti-cloud-service-common/pull/159
