### PR TITLE
fix: add missing equals() and hashCode() methods to Query JPA models

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/AbstractVariableEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/AbstractVariableEntity.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
@@ -178,6 +179,26 @@ public abstract class AbstractVariableEntity extends ActivitiEntityMetadata impl
     
     public void setProcessInstance(ProcessInstanceEntity processInstance) {
         this.processInstance = processInstance;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(id);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AbstractVariableEntity other = (AbstractVariableEntity) obj;
+        return Objects.equals(id, other.id);
     }
 
  }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessDefinitionEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessDefinitionEntity.java
@@ -16,6 +16,8 @@
 
 package org.activiti.cloud.services.query.model;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -108,5 +110,25 @@ public class ProcessDefinitionEntity extends ActivitiEntityMetadata implements C
 
     public void setFormKey(String formKey) {
         this.formKey = formKey;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(id);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ProcessDefinitionEntity other = (ProcessDefinitionEntity) obj;
+        return Objects.equals(id, other.id);
     }
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
@@ -273,4 +273,17 @@ public class ProcessInstanceEntity extends ActivitiEntityMetadata implements Clo
     }
     
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ProcessInstanceEntity other = (ProcessInstanceEntity) obj;
+        return Objects.equals(id, other.id);
+    }
+    
+
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.ConstraintMode;

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessModelEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessModelEntity.java
@@ -16,6 +16,8 @@
 
 package org.activiti.cloud.services.query.model;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -62,5 +64,22 @@ public class ProcessModelEntity {
 
     public String getProcessModelContent() {
         return processModelContent;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ProcessModelEntity other = (ProcessModelEntity) obj;
+        return Objects.equals(id, other.id);
     }
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
+
 import javax.persistence.Entity;
 import javax.persistence.Index;
 import javax.persistence.Table;
@@ -68,6 +69,22 @@ public class ProcessVariableEntity extends AbstractVariableEntity {
     @Override
     public boolean isTaskVariable() {
         return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        return true;
     }
 
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroup.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroup.java
@@ -1,5 +1,7 @@
 package org.activiti.cloud.services.query.model;
 
+import java.util.Objects;
+
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -62,5 +64,22 @@ public class TaskCandidateGroup {
 
     public void setTask(TaskEntity task) {
         this.task = task;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, taskId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TaskCandidateGroup other = (TaskCandidateGroup) obj;
+        return Objects.equals(groupId, other.groupId) && Objects.equals(taskId, other.taskId);
     }
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroupId.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateGroupId.java
@@ -3,6 +3,7 @@ package org.activiti.cloud.services.query.model;
 import java.io.Serializable;
 
 public class TaskCandidateGroupId implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String taskId;
     private String groupId;
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUser.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUser.java
@@ -1,5 +1,7 @@
 package org.activiti.cloud.services.query.model;
 
+import java.util.Objects;
+
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -72,5 +74,22 @@ public class TaskCandidateUser {
 
     public void setTask(TaskEntity task) {
         this.task = task;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(taskId, userId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TaskCandidateUser other = (TaskCandidateUser) obj;
+        return Objects.equals(taskId, other.taskId) && Objects.equals(userId, other.userId);
     }
 }

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUserId.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskCandidateUserId.java
@@ -3,6 +3,8 @@ package org.activiti.cloud.services.query.model;
 import java.io.Serializable;
 
 public class TaskCandidateUserId implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
     private String taskId;
     private String userId;
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.ConstraintMode;
@@ -493,6 +494,26 @@ public class TaskEntity extends ActivitiEntityMetadata implements CloudTask {
         return  !(TaskStatus.CREATED.equals(status) || 
                   TaskStatus.ASSIGNED.equals(status)|| 
                   TaskStatus.SUSPENDED.equals(status));
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(id);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TaskEntity other = (TaskEntity) obj;
+        return Objects.equals(id, other.id);
     }
     
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskVariableEntity.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskVariableEntity.java
@@ -17,6 +17,8 @@
 package org.activiti.cloud.services.query.model;
 
 import java.util.Date;
+import java.util.Objects;
+
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -97,6 +99,26 @@ public class TaskVariableEntity extends AbstractVariableEntity {
     @Override
     public boolean isTaskVariable() {
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(taskId);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TaskVariableEntity other = (TaskVariableEntity) obj;
+        return Objects.equals(taskId, other.taskId);
     }
     
 }


### PR DESCRIPTION
This PR adds missing equals() and hashCode() methods to Query JPA models in order to be able distinct objects using their identity.