### PR TITLE
fix(AAE-201): Refactored Query IT tests to use extended SecurityManager groups Apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ hs_err_pid*
 *.versionsBackup
 
 .springBeans
+
+.sts4-cache
+

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.activiti.cloud.conf;
 
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.services.query.rest.QueryRelProvider;
 import org.activiti.cloud.services.query.rest.assembler.ProcessDefinitionResourceAssembler;
@@ -81,10 +80,8 @@ public class QueryRestWebMvcAutoConfiguration  {
     
     @Bean
     @ConditionalOnMissingBean
-    public TaskLookupRestrictionService taskLookupRestrictionService(UserGroupManager userGroupManager,
-                                                                     SecurityManager securityManager) {
-        return new TaskLookupRestrictionService(userGroupManager, 
-                                                securityManager);
+    public TaskLookupRestrictionService taskLookupRestrictionService(SecurityManager securityManager) {
+        return new TaskLookupRestrictionService(securityManager);
     }    
 
     @Bean

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/security/TaskLookupRestrictionService.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/security/TaskLookupRestrictionService.java
@@ -2,7 +2,6 @@ package org.activiti.cloud.services.security;
 
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.services.query.model.QTaskEntity;
 import org.activiti.cloud.services.query.model.QTaskVariableEntity;
@@ -16,16 +15,12 @@ import java.util.List;
  */
 public class TaskLookupRestrictionService {
 
-    private final UserGroupManager userGroupManager;
-
     private final SecurityManager securityManager;
 
     @Value("${activiti.cloud.security.task.restrictions.enabled:true}")
     private boolean restrictionsEnabled;
 
-    public TaskLookupRestrictionService(UserGroupManager userGroupManager,
-                                        SecurityManager securityManager) {
-        this.userGroupManager = userGroupManager;
+    public TaskLookupRestrictionService(SecurityManager securityManager) {
         this.securityManager = securityManager;
     }
 
@@ -65,8 +60,8 @@ public class TaskLookupRestrictionService {
 
 
             List<String> groups = null;
-            if (userGroupManager != null) {
-                groups = userGroupManager.getUserGroups(userId);
+            if (securityManager != null) {
+                groups = securityManager.getAuthenticatedUserGroups();
             }
             if(groups!=null && groups.size()>0) {
                 //belongs to candidate group and task is not assigned

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictProcessInstanceEntityQueryIT.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictProcessInstanceEntityQueryIT.java
@@ -96,7 +96,7 @@ public class RestrictProcessInstanceEntityQueryIT {
         processInstanceRepository.save(processInstanceEntity);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("bobinhr");
-        when(userGroupManager.getUserGroups("bobinhr")).thenReturn(Collections.singletonList("hrgroup"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Collections.singletonList("hrgroup"));
 
         Predicate predicate = processInstanceRestrictionService.restrictProcessInstanceQuery(null, SecurityPolicyAccess.READ);
         Iterable<ProcessInstanceEntity> iterable = processInstanceRepository.findAll(predicate);

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictTaskEntityQueryIT.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictTaskEntityQueryIT.java
@@ -70,7 +70,7 @@ public class RestrictTaskEntityQueryIT {
         taskCandidateUserRepository.save(taskCandidateUser);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("testuser");
-        when(userGroupManager.getUserGroups("testuser")).thenReturn(Arrays.asList("testgroup"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Arrays.asList("testgroup"));
 
         Predicate predicate = taskLookupRestrictionService.restrictTaskQuery(null);
 
@@ -171,8 +171,8 @@ public class RestrictTaskEntityQueryIT {
         taskCandidateGroupRepository.save(taskCandidateGroup);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("hruser");
-        when(userGroupManager.getUserGroups("hruser")).thenReturn(Arrays.asList("hr"));
-
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Arrays.asList("hr"));
+        
         Predicate predicate = taskLookupRestrictionService.restrictTaskQuery(null);
 
         Iterable<TaskEntity> iterable = taskRepository.findAll(predicate);
@@ -190,7 +190,7 @@ public class RestrictTaskEntityQueryIT {
         taskCandidateGroupRepository.save(taskCandidateGroup);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("hruser");
-        when(userGroupManager.getUserGroups("hruser")).thenReturn(Arrays.asList("hr"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Arrays.asList("hr"));
 
         Predicate predicate = taskLookupRestrictionService.restrictTaskQuery(null);
 
@@ -210,7 +210,7 @@ public class RestrictTaskEntityQueryIT {
         taskCandidateGroupRepository.save(taskCandidateGroup);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("hruser");
-        when(userGroupManager.getUserGroups("hruser")).thenReturn(Arrays.asList("hr"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Arrays.asList("hr"));
 
         Predicate predicate = taskLookupRestrictionService.restrictTaskQuery(null);
 
@@ -306,7 +306,7 @@ public class RestrictTaskEntityQueryIT {
         taskCandidateGroupRepository.save(taskCandidateGroup);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("hruser");
-        when(userGroupManager.getUserGroups("hruser")).thenReturn(Arrays.asList("hr"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Arrays.asList("hr"));
 
         Predicate predicate = taskLookupRestrictionService.restrictTaskQuery(QTaskEntity.taskEntity.id.eq("7"));
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictVariableEntityQueryIT.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictVariableEntityQueryIT.java
@@ -100,7 +100,7 @@ public class RestrictVariableEntityQueryIT {
         taskCandidateUserRepository.save(taskCandidateUser);
 
         when(securityManager.getAuthenticatedUserId()).thenReturn("testuser");
-        when(userGroupManager.getUserGroups("testuser")).thenReturn(Arrays.asList("testgroup"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Arrays.asList("testgroup"));
 
         Predicate predicate = taskVariableLookupRestrictionService.restrictTaskVariableQuery(null);
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/security/ProcessDefinitionRestrictionServiceIT.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/security/ProcessDefinitionRestrictionServiceIT.java
@@ -136,7 +136,7 @@ public class ProcessDefinitionRestrictionServiceIT {
     public void shouldGetAllProcessDefinitionsAllowedToGroup() {
         //given
         when(securityManager.getAuthenticatedUserId()).thenReturn("bobinhr");
-        when(userGroupManager.getUserGroups("bobinhr")).thenReturn(Collections.singletonList("hrgroup"));
+        when(securityManager.getAuthenticatedUserGroups()).thenReturn(Collections.singletonList("hrgroup"));
 
         //when
         Predicate predicate = restrictionService.restrictProcessDefinitionQuery(null,

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
-    <activiti-dependencies.version>7.1.87</activiti-dependencies.version>
+    <activiti-dependencies.version>7.1.88</activiti-dependencies.version>
     <activiti-cloud-service-common.version>7.1.75</activiti-cloud-service-common.version>
     <activiti-cloud-query-service.version>${project.version}</activiti-cloud-query-service.version>
     <json-unit.version>1.24.0</json-unit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
-    <activiti-dependencies.version>7.1.88</activiti-dependencies.version>
+    <activiti-dependencies.version>7.1.89</activiti-dependencies.version>
     <activiti-cloud-service-common.version>7.1.75</activiti-cloud-service-common.version>
     <activiti-cloud-query-service.version>${project.version}</activiti-cloud-query-service.version>
     <json-unit.version>1.24.0</json-unit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
-    <activiti-dependencies.version>7.1.89</activiti-dependencies.version>
+    <activiti-dependencies.version>7.1.90</activiti-dependencies.version>
     <activiti-cloud-service-common.version>7.1.75</activiti-cloud-service-common.version>
     <activiti-cloud-query-service.version>${project.version}</activiti-cloud-query-service.version>
     <json-unit.version>1.24.0</json-unit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
     <activiti-dependencies.version>7.1.90</activiti-dependencies.version>
-    <activiti-cloud-service-common.version>7.1.75</activiti-cloud-service-common.version>
+    <activiti-cloud-service-common.version>7.1.76</activiti-cloud-service-common.version>
     <activiti-cloud-query-service.version>${project.version}</activiti-cloud-query-service.version>
     <json-unit.version>1.24.0</json-unit.version>
     <testcontainers.version>1.12.0</testcontainers.version>


### PR DESCRIPTION
This PR  refactores Query IT tests to use extended SecurityManager groups Apis from https://github.com/Activiti/activiti-api/pull/124.

Depends on https://github.com/Activiti/activiti-cloud-service-common/pull/174

Part of https://github.com/Activiti/Activiti/issues/2765