### PR TITLE
fix: applied nullability checks for predicate parameters due to DATAJPA-159 

### DIFF
--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminController.java
@@ -16,7 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
+import java.util.Optional;
+
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
@@ -32,6 +33,9 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
 
 @RestController
 @ExposesResourceFor(ProcessDefinitionEntity.class)
@@ -60,6 +64,10 @@ public class ProcessDefinitionAdminController {
     @GetMapping
     public PagedResources<Resource<CloudProcessDefinition>> findAll(@QuerydslPredicate(root = ProcessDefinitionEntity.class) Predicate predicate,
                                                                     Pageable pageable) {
+        
+        predicate = Optional.ofNullable(predicate)
+                            .orElseGet(BooleanBuilder::new);
+        
         return pagedResourcesAssembler.toResource(pageable,
                                                   repository.findAll(predicate,
                                                                      pageable),

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionController.java
@@ -16,7 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
+import java.util.Optional;
+
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
@@ -34,6 +35,9 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
 
 @RestController
 @ExposesResourceFor(ProcessDefinitionEntity.class)
@@ -66,8 +70,10 @@ public class ProcessDefinitionController {
     @GetMapping
     public PagedResources<Resource<CloudProcessDefinition>> findAll(@QuerydslPredicate(root = ProcessDefinitionEntity.class) Predicate predicate,
                                                                     Pageable pageable) {
-        Predicate extendedPredicate = processDefinitionRestrictionService.restrictProcessDefinitionQuery(predicate,
-                                                                                                  SecurityPolicyAccess.READ);
+        
+        Predicate extendedPredicate = processDefinitionRestrictionService.restrictProcessDefinitionQuery(Optional.ofNullable(predicate)
+                                                                                                                 .orElseGet(BooleanBuilder::new),
+                                                                                                         SecurityPolicyAccess.READ);
         return pagedResourcesAssembler.toResource(pageable,
                                                   repository.findAll(extendedPredicate,
                                                                      pageable),

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
@@ -16,7 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
+import java.util.Optional;
+
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
@@ -34,6 +35,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
 
 @RestController
 @RequestMapping(
@@ -67,14 +71,15 @@ public class ProcessInstanceAdminController {
     public PagedResources<Resource<CloudProcessInstance>> findAll(@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
                                                                   Pageable pageable) {
 
-
+        predicate = Optional.ofNullable(predicate)
+                            .orElseGet(BooleanBuilder::new);
+        
         return pagedResourcesAssembler.toResource(pageable,
                                                   processInstanceRepository.findAll(predicate,
                                                                                     pageable),
                                                   processInstanceResourceAssembler);
     }
     
-
     @RequestMapping(value = "/{processInstanceId}", method = RequestMethod.GET)
     public Resource<CloudProcessInstance> findById(@PathVariable String processInstanceId) {
 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
@@ -16,8 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.Optional;
+
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -43,6 +43,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 @RestController
 @RequestMapping(
@@ -90,7 +94,8 @@ public class ProcessInstanceController {
     public PagedResources<Resource<CloudProcessInstance>> findAll(@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
                                                                   Pageable pageable) {
 
-        predicate = processInstanceRestrictionService.restrictProcessInstanceQuery(predicate,
+        predicate = processInstanceRestrictionService.restrictProcessInstanceQuery(Optional.ofNullable(predicate)
+                                                                                           .orElseGet(BooleanBuilder::new),
                                                                                     SecurityPolicyAccess.READ);
 
         return pagedResourcesAssembler.toResource(pageable,
@@ -120,6 +125,8 @@ public class ProcessInstanceController {
     public PagedResources<Resource<CloudProcessInstance>> subprocesses(@PathVariable String processInstanceId,
                                                                 @QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
                                                                 Pageable pageable) {
+
+        predicate = Optional.ofNullable(predicate).orElseGet(BooleanBuilder::new);
 
         ProcessInstanceEntity processInstanceEntity = entityFinder.findById(processInstanceRepository,
                                                                             processInstanceId,

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableAdminController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableAdminController.java
@@ -16,8 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.Optional;
+
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
@@ -35,6 +35,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 @RestController
 @RequestMapping(
@@ -64,7 +68,9 @@ public class ProcessInstanceVariableAdminController {
     public PagedResources<Resource<CloudVariableInstance>> getVariables(@PathVariable String processInstanceId,
                                                                         @QuerydslPredicate(root = ProcessVariableEntity.class) Predicate predicate,
                                                                         Pageable pageable) {
-
+        predicate = Optional.ofNullable(predicate)
+                            .orElseGet(BooleanBuilder::new);
+        
         QProcessVariableEntity variable = QProcessVariableEntity.processVariableEntity;
         
         //We will show only not deleted variables 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableController.java
@@ -16,8 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.Optional;
+
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
@@ -36,6 +36,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 @RestController
 @RequestMapping(
@@ -66,6 +70,9 @@ public class ProcessInstanceVariableController {
                                                                         @QuerydslPredicate(root = ProcessVariableEntity.class) Predicate predicate,
                                                                         Pageable pageable) {
 
+        predicate = Optional.ofNullable(predicate)
+                            .orElseGet(BooleanBuilder::new);
+        
         QProcessVariableEntity variable = QProcessVariableEntity.processVariableEntity;
         
         //We will show only not deleted variables 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -17,10 +17,9 @@
 package org.activiti.cloud.services.query.rest;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
@@ -43,6 +42,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 @RestController
 @RequestMapping(
@@ -77,7 +80,8 @@ public class TaskAdminController {
                                                        @RequestParam(name = "standalone", defaultValue = "false") Boolean standalone,
                                                        @QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
                                                        Pageable pageable) {
-        Predicate extendedPredicate=predicate;
+        Predicate extendedPredicate = Optional.ofNullable(predicate)
+                                              .orElseGet(BooleanBuilder::new);
         if (rootTasksOnly) {
             BooleanExpression parentTaskNull = QTaskEntity.taskEntity.parentTaskId.isNull(); 
             extendedPredicate= extendedPredicate !=null ? parentTaskNull.and(extendedPredicate) : parentTaskNull;

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -17,10 +17,9 @@
 package org.activiti.cloud.services.query.rest;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.task.model.CloudTask;
@@ -48,6 +47,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 @RestController
 @RequestMapping(
@@ -92,7 +95,8 @@ public class TaskController {
                                                        @RequestParam(name = "standalone", defaultValue = "false") Boolean standalone,
                                                        @QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
                                                        Pageable pageable) {
-        Predicate extendedPredicate=predicate;
+        Predicate extendedPredicate = Optional.ofNullable(predicate)
+                                              .orElseGet(BooleanBuilder::new);
         if (rootTasksOnly) {
             BooleanExpression parentTaskNull = QTaskEntity.taskEntity.parentTaskId.isNull(); 
             extendedPredicate= extendedPredicate !=null ? parentTaskNull.and(extendedPredicate) : parentTaskNull;

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableAdminController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableAdminController.java
@@ -16,8 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.Optional;
+
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
@@ -35,6 +35,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 @RestController
 @RequestMapping(
@@ -66,6 +70,9 @@ public class TaskVariableAdminController {
                                                                         @QuerydslPredicate(root = TaskVariableEntity.class) Predicate predicate,
                                                                         Pageable pageable) {
 
+        predicate = Optional.ofNullable(predicate)
+                            .orElseGet(BooleanBuilder::new);
+        
         QTaskVariableEntity variable = QTaskVariableEntity.taskVariableEntity;
 
         //We will show only not deleted variables 

--- a/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableController.java
+++ b/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableController.java
@@ -16,8 +16,8 @@
 
 package org.activiti.cloud.services.query.rest;
 
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.Optional;
+
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
@@ -36,6 +36,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 @RestController
 @RequestMapping(
@@ -67,6 +71,9 @@ public class TaskVariableController {
                                                                         @QuerydslPredicate(root = TaskVariableEntity.class) Predicate predicate,
                                                                         Pageable pageable) {
 
+        predicate = Optional.ofNullable(predicate)
+                            .orElseGet(BooleanBuilder::new);
+        
         QTaskVariableEntity variable = QTaskVariableEntity.taskVariableEntity;
         
         BooleanExpression expression = variable.taskId.eq(taskId);  


### PR DESCRIPTION
Problem is happening when page and size parameters are set which is the result of  DATAJPA-1594 - Revised nullability enforcement in Querydsl: https://github.com/spring-projects/spring-data-jpa/commit/62273d430dfc13286dfb30e915053420e59d6246

Spring Data `QuerydslJpaPredicateExecutor` is now throwing exceptions for null predicate values:

https://github.com/spring-projects/spring-data-jpa/blame/master/src/main/java/org/springframework/data/jpa/repository/support/QuerydslJpaPredicateExecutor.java#L156

The fix applies nullability checks for Predicate arguments with 

```
predicate = Optional.ofNullable(predicate).orElseGet(BooleanBuilder::new);
```