### PR TITLE
fix(AAE-731): Added Query consumer metadata properties placeholders

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
       ORG               = 'activiti'
       APP_NAME          = 'activiti-cloud-query-service'
       CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      RELEASE_BRANCH = "develop"
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -13,7 +14,7 @@ pipeline {
           branch 'PR-*'
         }
         environment {
-          PREVIEW_VERSION = "7.1.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+          PREVIEW_VERSION = maven_project_version().replaceAll("SNAPSHOT","$BRANCH_NAME-$BUILD_NUMBER-SNAPSHOT")
           PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
           HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
         }
@@ -28,38 +29,38 @@ pipeline {
       }
       stage('Build Release') {
         when {
-          branch 'develop'
+          branch "$RELEASE_BRANCH"
+        }
+        environment {
+          VERSION = jx_release_version()      
         }
         steps {
           container('maven') {
             // ensure we're not on a detached head
-            sh "git checkout develop" 
+            sh "git checkout $RELEASE_BRANCH" 
             sh "git config --global credential.helper store"
 
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
-            sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
+            sh "echo $VERSION > VERSION"
+            sh "mvn versions:set -DnewVersion=$VERSION"
             sh 'mvn clean verify'
 
             retry(5){
               sh "git add --all"
-              sh "git commit -m \"Release \$(cat VERSION)\" --allow-empty"
-              sh "git tag -fa v\$(cat VERSION) -m \"Release version \$(cat VERSION)\""
-              sh "git push origin v\$(cat VERSION)"
+              sh "git commit -m \"Release $VERSION\" --allow-empty"
+              sh "git tag -fa v$VERSION -m \"Release version $VERSION\""
+              sh "git push origin v$VERSION"
             }
-          }
-          container('maven') {
+
             sh 'mvn clean deploy -DskipTests'
 
-            sh 'export VERSION=`cat VERSION`'
-            
             sh "jx step git credentials"
             retry(2){
-              sh "updatebot push-version --kind maven org.activiti.cloud.query:activiti-cloud-query-dependencies \$(cat VERSION)"
+              sh "updatebot push-version --kind maven org.activiti.cloud.query:activiti-cloud-query-dependencies $VERSION"
               sh "rm -rf .updatebot-repos/"
               sh "sleep \$((RANDOM % 10))"
-              sh "updatebot push-version --kind maven org.activiti.cloud.query:activiti-cloud-query-dependencies \$(cat VERSION)"
+              sh "updatebot push-version --kind maven org.activiti.cloud.query:activiti-cloud-query-dependencies $VERSION"
             }
           }
         }
@@ -112,4 +113,18 @@ pipeline {
             cleanWs()
         }
     }
-  }
+}
+
+
+def jx_release_version() {
+    container('maven') {
+        return sh( script: "echo \$(jx-release-version)", returnStdout: true).trim()
+    }
+}
+
+def maven_project_version() {
+    container('maven') {
+        return sh( script: "echo \$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -f pom.xml)", returnStdout: true).trim()
+    }
+}  
+

--- a/activiti-cloud-starter-query/src/main/resources/metadata.properties
+++ b/activiti-cloud-starter-query/src/main/resources/metadata.properties
@@ -6,3 +6,9 @@ spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=classpath:config/query/liquibase/master.xml
 spring.liquibase.database-change-log-table=DATABASECHANGELOG_QUERY
 spring.liquibase.database-change-log-lock-table=DATABASECHANGELOGLOCK_QUERY
+
+spring.cloud.stream.bindings.auditConsumer.consumer.partitioned=${ACT_QUERY_CONSUMER_PARTITIONED:false}
+spring.cloud.stream.bindings.auditConsumer.consumer.instance-count=${ACT_QUERY_CONSUMER_INSTANCE_COUNT:1}
+spring.cloud.stream.bindings.auditConsumer.consumer.instance-index=${ACT_QUERY_CONSUMER_INSTANCE_INDEX:0}
+spring.cloud.stream.bindings.auditConsumer.consumer.concurrency=${ACT_QUERY_CONSUMER_CONCURRENCY:1}
+spring.cloud.stream.rabbit.bindings.auditConsumer.consumer.prefetch=${ACT_QUERY_CONSUMER_PREFETCH:20}

--- a/activiti-cloud-starter-query/src/main/resources/metadata.properties
+++ b/activiti-cloud-starter-query/src/main/resources/metadata.properties
@@ -7,8 +7,8 @@ spring.liquibase.change-log=classpath:config/query/liquibase/master.xml
 spring.liquibase.database-change-log-table=DATABASECHANGELOG_QUERY
 spring.liquibase.database-change-log-lock-table=DATABASECHANGELOGLOCK_QUERY
 
-spring.cloud.stream.bindings.auditConsumer.consumer.partitioned=${ACT_QUERY_CONSUMER_PARTITIONED:false}
-spring.cloud.stream.bindings.auditConsumer.consumer.instance-count=${ACT_QUERY_CONSUMER_INSTANCE_COUNT:1}
-spring.cloud.stream.bindings.auditConsumer.consumer.instance-index=${ACT_QUERY_CONSUMER_INSTANCE_INDEX:0}
-spring.cloud.stream.bindings.auditConsumer.consumer.concurrency=${ACT_QUERY_CONSUMER_CONCURRENCY:1}
-spring.cloud.stream.rabbit.bindings.auditConsumer.consumer.prefetch=${ACT_QUERY_CONSUMER_PREFETCH:20}
+spring.cloud.stream.bindings.queryConsumer.consumer.partitioned=${ACT_QUERY_CONSUMER_PARTITIONED:false}
+spring.cloud.stream.bindings.queryConsumer.consumer.instance-count=${ACT_QUERY_CONSUMER_INSTANCE_COUNT:1}
+spring.cloud.stream.bindings.queryConsumer.consumer.instance-index=${ACT_QUERY_CONSUMER_INSTANCE_INDEX:0}
+spring.cloud.stream.bindings.queryConsumer.consumer.concurrency=${ACT_QUERY_CONSUMER_CONCURRENCY:1}
+spring.cloud.stream.rabbit.bindings.queryConsumer.consumer.prefetch=${ACT_QUERY_CONSUMER_PREFETCH:20}


### PR DESCRIPTION
This PR adds property placeholders into metadata.properties in order to be able to configure query consumer Spring Cloud Stream properties via Helm chart.

```
spring.cloud.stream.bindings.auditConsumer.consumer.partitioned=${ACT_QUERY_CONSUMER_PARTITIONED:false}
spring.cloud.stream.bindings.auditConsumer.consumer.instance-count=${ACT_QUERY_CONSUMER_INSTANCE_COUNT:1}
spring.cloud.stream.bindings.auditConsumer.consumer.instance-index=${ACT_QUERY_CONSUMER_INSTANCE_INDEX:0}
spring.cloud.stream.bindings.auditConsumer.consumer.concurrency=${ACT_QUERY_CONSUMER_CONCURRENCY:1}
spring.cloud.stream.rabbit.bindings.auditConsumer.consumer.prefetch=${ACT_QUERY_CONSUMER_PREFETCH:20}

```

Fixes AAE-731